### PR TITLE
Add product page generator

### DIFF
--- a/products/dried-apricots.html
+++ b/products/dried-apricots.html
@@ -1,0 +1,39 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sun-Dried Apricots - Terrabi</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;500;600&family=Pacifico&display=swap" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com/3.4.16"></script>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50 font-sans">
+<header class="bg-white shadow-sm">
+  <div class="max-w-7xl mx-auto p-4">
+    <a href="index.html" class="text-primary">&larr; Back to products</a>
+  </div>
+</header>
+<main class="max-w-3xl mx-auto p-4">
+  <h1 class="text-3xl font-bold mb-4">Sun-Dried Apricots</h1>
+  <img src="/assets/images/products/3.jpg" alt="Sun-Dried Apricots" class="w-full mb-4 rounded">
+  <p class="mb-4">Naturally sun-dried apricots rich in flavor and nutrients, no additives.</p>
+  <table class="w-full mb-4">
+    <tr><td class="font-semibold pr-2">Category:</td><td>Dried Fruits</td></tr>
+    <tr><td class="font-semibold pr-2">Origin:</td><td>Uzbekistan</td></tr>
+    <tr><td class="font-semibold pr-2">Price:</td><td>$3.8 / MT</td></tr>
+    <tr><td class="font-semibold pr-2">Min Order:</td><td>200 MT</td></tr>
+  </table>
+  <h2 class="text-xl font-semibold mb-2">Packaging</h2>
+<ul class="list-disc pl-5 mb-4"><li>5kg box</li>
+<li>12.5kg carton</li>
+<li>bulk</li></ul>
+  <h2 class="text-xl font-semibold mb-2">Certifications</h2>
+<ul class="list-disc pl-5 mb-4"><li>Organic Certified</li>
+<li>HACCP</li></ul>
+</main>
+</body>
+</html>

--- a/products/long-grain-rice.html
+++ b/products/long-grain-rice.html
@@ -1,0 +1,37 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Long Grain Rice - Terrabi</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;500;600&family=Pacifico&display=swap" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com/3.4.16"></script>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50 font-sans">
+<header class="bg-white shadow-sm">
+  <div class="max-w-7xl mx-auto p-4">
+    <a href="index.html" class="text-primary">&larr; Back to products</a>
+  </div>
+</header>
+<main class="max-w-3xl mx-auto p-4">
+  <h1 class="text-3xl font-bold mb-4">Long Grain Rice</h1>
+  <img src="/assets/images/products/1.jpg" alt="Long Grain Rice" class="w-full mb-4 rounded">
+  <p class="mb-4">Premium long grain rice from the Fergana Valley.</p>
+  <table class="w-full mb-4">
+    <tr><td class="font-semibold pr-2">Category:</td><td>Rice</td></tr>
+    <tr><td class="font-semibold pr-2">Origin:</td><td>Uzbekistan</td></tr>
+    <tr><td class="font-semibold pr-2">Price:</td><td>$0.95 / MT</td></tr>
+    <tr><td class="font-semibold pr-2">Min Order:</td><td>1000 MT</td></tr>
+  </table>
+  <h2 class="text-xl font-semibold mb-2">Packaging</h2>
+<ul class="list-disc pl-5 mb-4"><li>10kg bag</li>
+<li>25kg bag</li></ul>
+  <h2 class="text-xl font-semibold mb-2">Certifications</h2>
+<ul class="list-disc pl-5 mb-4"><li>ISO 22000</li></ul>
+</main>
+</body>
+</html>

--- a/products/organic-mung-beans.html
+++ b/products/organic-mung-beans.html
@@ -1,0 +1,38 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Organic Mung Beans - Terrabi</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;500;600&family=Pacifico&display=swap" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com/3.4.16"></script>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50 font-sans">
+<header class="bg-white shadow-sm">
+  <div class="max-w-7xl mx-auto p-4">
+    <a href="index.html" class="text-primary">&larr; Back to products</a>
+  </div>
+</header>
+<main class="max-w-3xl mx-auto p-4">
+  <h1 class="text-3xl font-bold mb-4">Organic Mung Beans</h1>
+  <img src="/images/products/mung.jpg" alt="Organic Mung Beans" class="w-full mb-4 rounded">
+  <p class="mb-4">High-quality mung beans, ideal for export.</p>
+  <table class="w-full mb-4">
+    <tr><td class="font-semibold pr-2">Category:</td><td>Legumes</td></tr>
+    <tr><td class="font-semibold pr-2">Origin:</td><td>Uzbekistan</td></tr>
+    <tr><td class="font-semibold pr-2">Price:</td><td>$1.25 / MT</td></tr>
+    <tr><td class="font-semibold pr-2">Min Order:</td><td>500 MT</td></tr>
+  </table>
+  <h2 class="text-xl font-semibold mb-2">Packaging</h2>
+<ul class="list-disc pl-5 mb-4"><li>25kg bag</li>
+<li>1 ton bulk</li></ul>
+  <h2 class="text-xl font-semibold mb-2">Certifications</h2>
+<ul class="list-disc pl-5 mb-4"><li>ISO 22000</li>
+<li>Organic Certified</li></ul>
+</main>
+</body>
+</html>

--- a/products/organic-red-kidney-beans.html
+++ b/products/organic-red-kidney-beans.html
@@ -1,0 +1,37 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Organic Red Kidney Beans - Terrabi</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;500;600&family=Pacifico&display=swap" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com/3.4.16"></script>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50 font-sans">
+<header class="bg-white shadow-sm">
+  <div class="max-w-7xl mx-auto p-4">
+    <a href="index.html" class="text-primary">&larr; Back to products</a>
+  </div>
+</header>
+<main class="max-w-3xl mx-auto p-4">
+  <h1 class="text-3xl font-bold mb-4">Organic Red Kidney Beans</h1>
+  <img src="/images/products/kidney.jpg" alt="Organic Red Kidney Beans" class="w-full mb-4 rounded">
+  <p class="mb-4">Rich in protein and iron, ideal for export markets.</p>
+  <table class="w-full mb-4">
+    <tr><td class="font-semibold pr-2">Category:</td><td>Beans</td></tr>
+    <tr><td class="font-semibold pr-2">Origin:</td><td>Uzbekistan</td></tr>
+    <tr><td class="font-semibold pr-2">Price:</td><td>$1.15 / MT</td></tr>
+    <tr><td class="font-semibold pr-2">Min Order:</td><td>800 MT</td></tr>
+  </table>
+  <h2 class="text-xl font-semibold mb-2">Packaging</h2>
+<ul class="list-disc pl-5 mb-4"><li>20kg bag</li>
+<li>bulk</li></ul>
+  <h2 class="text-xl font-semibold mb-2">Certifications</h2>
+<ul class="list-disc pl-5 mb-4"><li>Organic Certified</li></ul>
+</main>
+</body>
+</html>

--- a/products/walnuts.html
+++ b/products/walnuts.html
@@ -1,0 +1,39 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Organic Walnuts - Terrabi</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;500;600&family=Pacifico&display=swap" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com/3.4.16"></script>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50 font-sans">
+<header class="bg-white shadow-sm">
+  <div class="max-w-7xl mx-auto p-4">
+    <a href="index.html" class="text-primary">&larr; Back to products</a>
+  </div>
+</header>
+<main class="max-w-3xl mx-auto p-4">
+  <h1 class="text-3xl font-bold mb-4">Organic Walnuts</h1>
+  <img src="/assets/images/products/1.jpg" alt="Organic Walnuts" class="w-full mb-4 rounded">
+  <p class="mb-4">Premium quality organic walnuts grown in the fertile valleys of Uzbekistan.</p>
+  <table class="w-full mb-4">
+    <tr><td class="font-semibold pr-2">Category:</td><td>Nuts</td></tr>
+    <tr><td class="font-semibold pr-2">Origin:</td><td>Uzbekistan</td></tr>
+    <tr><td class="font-semibold pr-2">Price:</td><td>$4.5 / MT</td></tr>
+    <tr><td class="font-semibold pr-2">Min Order:</td><td>100 MT</td></tr>
+  </table>
+  <h2 class="text-xl font-semibold mb-2">Packaging</h2>
+<ul class="list-disc pl-5 mb-4"><li>10kg vacuum pack</li>
+<li>25kg sack</li>
+<li>bulk</li></ul>
+  <h2 class="text-xl font-semibold mb-2">Certifications</h2>
+<ul class="list-disc pl-5 mb-4"><li>Organic Certified</li>
+<li>ISO 22000</li></ul>
+</main>
+</body>
+</html>

--- a/scripts/generate_product_pages.py
+++ b/scripts/generate_product_pages.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+
+PRODUCTS_DIR = Path(__file__).resolve().parents[1] / "products"
+TEMPLATE = """
+<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"UTF-8\">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
+<title>{title} - Terrabi</title>
+<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">
+<link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>
+<link href=\"https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;500;600&family=Pacifico&display=swap\" rel=\"stylesheet\">
+<script src=\"https://cdn.tailwindcss.com/3.4.16\"></script>
+<link href=\"https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css\" rel=\"stylesheet\">
+</head>
+<body class=\"bg-gray-50 font-sans\">
+<header class=\"bg-white shadow-sm\">
+  <div class=\"max-w-7xl mx-auto p-4\">
+    <a href=\"index.html\" class=\"text-primary\">&larr; Back to products</a>
+  </div>
+</header>
+<main class=\"max-w-3xl mx-auto p-4\">
+  <h1 class=\"text-3xl font-bold mb-4\">{title}</h1>
+  <img src=\"{image}\" alt=\"{title}\" class=\"w-full mb-4 rounded\">
+  <p class=\"mb-4\">{description}</p>
+  <table class=\"w-full mb-4\">
+    <tr><td class=\"font-semibold pr-2\">Category:</td><td>{category}</td></tr>
+    <tr><td class=\"font-semibold pr-2\">Origin:</td><td>{origin}</td></tr>
+    <tr><td class=\"font-semibold pr-2\">Price:</td><td>${price} / MT</td></tr>
+    <tr><td class=\"font-semibold pr-2\">Min Order:</td><td>{min_order} MT</td></tr>
+  </table>
+  {packaging_block}
+  {cert_block}
+</main>
+</body>
+</html>
+"""
+
+def format_list_block(title, items):
+    if not items:
+        return ""
+    lis = "\n".join(f"<li>{item}</li>" for item in items)
+    return f"<h2 class=\"text-xl font-semibold mb-2\">{title}</h2>\n<ul class=\"list-disc pl-5 mb-4\">{lis}</ul>"
+
+def main():
+    for json_file in PRODUCTS_DIR.glob("*.json"):
+        with open(json_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        packaging_block = format_list_block("Packaging", data.get("packaging"))
+        cert_block = format_list_block("Certifications", data.get("certifications"))
+        html = TEMPLATE.format(
+            title=data.get("title", ""),
+            image=data.get("image", ""),
+            description=data.get("description", ""),
+            category=data.get("category", ""),
+            origin=data.get("origin", ""),
+            price=data.get("price", ""),
+            min_order=data.get("min_order", ""),
+            packaging_block=packaging_block,
+            cert_block=cert_block,
+        )
+        out_file = PRODUCTS_DIR / f"{json_file.stem}.html"
+        with open(out_file, "w", encoding="utf-8") as f:
+            f.write(html)
+        print(f"Generated {out_file}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to generate product detail pages from JSON
- generate initial product pages

## Testing
- `python3 scripts/generate_product_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_684d6e2d5c488327a6e74a37f73bfec2